### PR TITLE
setup.py had an error. tpdm should be tqdm. Fixed it.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ setup(
     py_modules=['cbz_editor'],
     install_requires=[
         'click',
-        'tpdm'
+        'tqdm'
     ],
     entry_points='''
         [console_scripts]


### PR DESCRIPTION
When attempting to compile the program through `pip install -e .`  I was given the following error: 

```
Obtaining file:///mnt/c/Users/LockNet/Desktop/projects/cbz_editor
  Installing build dependencies ... done
  Checking if build backend supports build_editable ... done
  Getting requirements to build editable ... done
  Preparing editable metadata (pyproject.toml) ... done
Requirement already satisfied: click in ./venv/lib/python3.12/site-packages (from cbz_editor==0.1) (8.3.1)
INFO: pip is looking at multiple versions of cbz-editor to determine which version is compatible with other requirements. This could take a while.
ERROR: Could not find a version that satisfies the requirement tpdm (from cbz-editor) (from versions: none)
ERROR: No matching distribution found for tpdm
```

When I changed `tpdm` to `tqdm`, the issue was resolved. 