### PR TITLE
'ElementTree' is not defined. This is fixed.

### DIFF
--- a/cbz_editor.py
+++ b/cbz_editor.py
@@ -52,9 +52,9 @@ def save_config(series_name: str, writer_name: str) -> None:
     writer_element = SubElement(config, 'writer_name')
     writer_element.text = writer_name
 
-    tree = ElementTree(config)
     with open(CONFIG_FILE, 'wb') as f:
-        tree.write(f)
+        f.write(tostring(config, encoding='utf-8', xml_declaration=True))
+
     logging.info(f"Configuration saved to {CONFIG_FILE}")
 
 @cli.command()


### PR DESCRIPTION
When using `cbz_editor init` it throws the following issue: 

```
Traceback (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "C:\Users\LockNet\Downloads\cbz_editor\venv\Scripts\cbz_editor.exe\__main__.py", line 7, in <module>
  File "C:\Users\LockNet\Downloads\cbz_editor\venv\Lib\site-packages\click\core.py", line 1485, in __call__
    return self.main(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\LockNet\Downloads\cbz_editor\venv\Lib\site-packages\click\core.py", line 1406, in main
    rv = self.invoke(ctx)
         ^^^^^^^^^^^^^^^^
  File "C:\Users\LockNet\Downloads\cbz_editor\venv\Lib\site-packages\click\core.py", line 1873, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\LockNet\Downloads\cbz_editor\venv\Lib\site-packages\click\core.py", line 1269, in invoke
    return ctx.invoke(self.callback, **ctx.params)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\LockNet\Downloads\cbz_editor\venv\Lib\site-packages\click\core.py", line 824, in invoke
    return callback(*args, **kwargs)
  File "C:\Users\LockNet\Downloads\cbz_editor\venv\Lib\site-packages\click\core.py", line 824, in invoke
    return callback(*args, **kwargs)
  File "C:\Users\LockNet\Downloads\cbz_editor\venv\Lib\site-packages\click\core.py", line 824, in invoke
  File "C:\Users\LockNet\Downloads\cbz_editor\venv\Lib\site-packages\click\core.py", line 824, in invoke
  File "C:\Users\LockNet\Downloads\cbz_editor\venv\Lib\site-packages\click\core.py", line 824, in invoke
  File "C:\Users\LockNet\Downloads\cbz_editor\venv\Lib\site-packages\click\core.py", line 824, in invoke
    return callback(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\LockNet\Downloads\cbz_editor\cbz_editor.py", line 33, in init
    save_config(series_name, writer_name)
  File "C:\Users\LockNet\Downloads\cbz_editor\cbz_editor.py", line 55, in save_config
    tree = ElementTree(config)
           ^^^^^^^^^^^
NameError: name 'ElementTree' is not defined
```

The changes I have made fixes this issue when running `cbz_editor init`.